### PR TITLE
GetExternalUrl produced invalid URL if QS param contained slash.

### DIFF
--- a/base/SMEnvironment.class.php
+++ b/base/SMEnvironment.class.php
@@ -454,12 +454,17 @@ class SMEnvironment
 	/// </function>
 	public static function GetExternalUrl()
 	{
+		$ruri = $_SERVER["REQUEST_URI"];
+		$ruri = (strpos($ruri, "?") !== false ? substr($ruri, 0, strpos($ruri, "?")) : $ruri); // Remove query string parameters which may contain a slash (e.g. https://localhost/demo/?SMExt=SMDesigner&SMCallback=callbacks/test)
+		$ruri = substr($ruri, 0, strrpos($ruri, "/"));
+
 		$url = "";
 		$url .= "http";
 		$url .= ((isset($_SERVER["HTTPS"]) === true && $_SERVER["HTTPS"] !== "off") ? "s://" : "://");
 		$url .= $_SERVER["SERVER_NAME"];
-		$url .= (($_SERVER["SERVER_PORT"] !== "80") ? ":" . $_SERVER["SERVER_PORT"] : "");
-		$url .= substr($_SERVER["REQUEST_URI"], 0, strrpos($_SERVER["REQUEST_URI"], "/"));
+		$url .= (($_SERVER["SERVER_PORT"] !== "80" && $_SERVER["SERVER_PORT"] !== "443") ? ":" . $_SERVER["SERVER_PORT"] : "");
+		$url .= $ruri;
+		//$url .= substr($_SERVER["REQUEST_URI"], 0, strrpos($_SERVER["REQUEST_URI"], "/"));
 		//$url .= substr($_SERVER["PHP_SELF"], 0, strrpos($_SERVER["PHP_SELF"], "/")); // Not reliable when URL Rewriting is used (e.g. sub.domain.com => domain.com/sites/sub)
 
 		return $url; // e.g. http://www.domain.com/demo/cms


### PR DESCRIPTION
SMEnvironment::GetExternalUrl() did not return the expected value if a URL parameter contained a slash - e.g. https://localhost/demo/?SMExt=SMDesigner&SMCallback=callbacks/test.
Notice how the SMCallback parameter contains a value with a slash (/). Bug has now been fixed.

Also made sure port 443 is no longer appended to URL for websites running on HTTPS (e.g. https://sitemagic.org:443).